### PR TITLE
feat: 가계부 레포트 페이지 구현, normalize css 적용, financeContext파일 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.7.9",
+        "normalize.css": "^8.0.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.1.1",
@@ -3312,6 +3313,12 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize.css": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==",
       "license": "MIT"
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "axios": "^1.7.9",
+    "normalize.css": "^8.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.1.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { BrowserRouter as Router, Routes, Route  } from "react-router-dom";
+import "normalize.css"
 import "./index.css";
 
 import Layout from "./layouts/layout"; // 레이아웃
@@ -16,6 +17,7 @@ import ProfileSetting from './pages/ProfileSetting'; // 프로필 설정
 import User from './pages/User'; // 마이페이지
 import Finance from './pages/Finance'; // 가계부
 import FinanceMain from './pages/Finance/FinanceMain';
+import Report from './pages/Finance/Report';
 import HandWrite from './pages/Finance/HandWrite';
 import NotFound from './pages/NotFound';
 import PostWrite from './pages/Community/PostWrite'; // 글쓰기 페이지
@@ -41,6 +43,7 @@ function App() {
           {/* 가계부 페이지 */}
           <Route path="/finance" element={<Finance />} >
             <Route index element={<FinanceMain />} />
+            <Route path="report" element={<Report />} />
             <Route path="handwrite" element={<HandWrite />} />
           </Route>
 

--- a/src/contexts/financeContext.jsx
+++ b/src/contexts/financeContext.jsx
@@ -1,0 +1,18 @@
+import { createContext, useState } from "react";
+
+export const FinanceContext = createContext();
+
+export function FinanceProvider({ children }) {
+    const today = new Date();
+    const [selectedDate, setSelectedDate] = useState({
+        year: today.getFullYear(),
+        month: today.getMonth() + 1,
+        day: today.getDate()
+    });
+
+    return (
+        <FinanceContext.Provider value={{selectedDate, setSelectedDate}}>
+            {children}
+        </FinanceContext.Provider>
+    );
+}

--- a/src/pages/Finance/Report/index.jsx
+++ b/src/pages/Finance/Report/index.jsx
@@ -1,0 +1,17 @@
+import React, { useContext } from 'react';
+import BeforeHeader from '../../../components/common/BeforeHeader';
+import NavBar from '../../../components/common/NavBar';
+import { FinanceContext } from '../../../contexts/financeContext';
+import * as S from '../../../styles/Finance/Report/style';
+
+const Report = () => {
+    const { selectedDate, setSelectedDate } = useContext(FinanceContext);
+    return (
+        <S.Container>
+            <BeforeHeader text="경제 활동 만족도 레포트" />
+            <NavBar selectedDate={selectedDate} setSeletedDate={setSelectedDate} modalTop="132px"/>
+        </S.Container>
+    );
+};
+
+export default Report;

--- a/src/pages/Finance/index.jsx
+++ b/src/pages/Finance/index.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
+import { FinanceProvider } from '../../contexts/financeContext';
 
 const Finance = () => {
     return (
-        <>
+        <FinanceProvider>
             <Outlet />
-        </>
+        </FinanceProvider>
     );
 };
 

--- a/src/styles/Finance/Report/style.js
+++ b/src/styles/Finance/Report/style.js
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    width: 90%;
+    left: 5%;
+    top: 44px;
+    gap: 20px;
+`;

--- a/src/styles/common/BeforeHeader/style.js
+++ b/src/styles/common/BeforeHeader/style.js
@@ -25,4 +25,5 @@ export const Title = styled.h1`
   position: absolute;
   left: 50%;
   transform: translateX(-50%); 
+  white-space: nowrap; /* 줄바꿈 방지 */
 `;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #19 

## 📝작업 내용

> 가계부 레포트 페이지를 구현하였습니다.
> normalize css를 프로젝트에 적용하였습니다.
> selectedDate와 setSelectedDate의 값을 finance 페이지 내부에서 공유하기 위해서 financeContext파일을 제작하였습니다.

https://github.com/user-attachments/assets/5e545bec-1897-47ec-881d-d273d0f06182

## 💬리뷰 요구사항

> 가계부 레포트 페이지의 스타일링은 추후에 수정하도록 하겠습니다.
