### PR TITLE
feat: 회원가입 기능 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { BrowserRouter as Router, Routes, Route  } from "react-router-dom";
+import { AuthProvider } from './contexts/AuthContext';
 import "normalize.css"
 import "./index.css";
 
@@ -47,7 +48,7 @@ function App() {
   const [count, setCount] = useState(0);
 
   return (
-    <>
+    <AuthProvider>
       <Router>
         <Routes>
           {/* 온보딩 페이지 */}
@@ -114,7 +115,7 @@ function App() {
 
         </Routes>
     </Router>
-    </>
+    </AuthProvider>
   )
 }
 

--- a/src/api/axiosInstance.js
+++ b/src/api/axiosInstance.js
@@ -1,0 +1,58 @@
+import axios from "axios";
+
+// Axios 인스턴스 생성
+const axiosInstance = axios.create({
+    baseURL: import.meta.env.VITE_API_URL, // API의 기본 URL
+});
+
+// 요청 인터셉터 설정
+axiosInstance.interceptors.request.use(
+    (config) => {
+        const accessToken = localStorage.getItem("token"); // Access Token 가져오기
+        if (accessToken) {
+            config.headers["Authorization"] = `Bearer ${accessToken}`; // Authorization 헤더 추가
+        }
+        return config;
+    },
+    (error) => Promise.reject(error)
+);
+
+// 응답 인터셉터 설정
+axiosInstance.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+        const originalRequest = error.config;
+
+        // Access Token 만료 에러(403 Unauthorized) 처리
+        if (error.response && error.response.status === 403 && !originalRequest._retry) {
+            originalRequest._retry = true; // 무한 루프 방지
+
+            try {
+                // Access Token 재발급 요청
+                const response = await axios.post(
+                    `${import.meta.env.VITE_API_URL}/api/auth/refresh`,
+                    {
+                        oldAccessToken: localStorage.getItem("token"), // 기존 Access Token
+                    }
+                );
+
+                const newAccessToken = response.data.accessToken; // 새 Access Token
+                localStorage.setItem("token", newAccessToken); // 새 Access Token 저장
+
+                // 원래 요청에 새 Access Token 추가
+                originalRequest.headers["Authorization"] = `Bearer ${newAccessToken}`;
+                return axiosInstance(originalRequest); // 원래 요청 재시도
+            } catch (error) {
+                console.error("Access Token 재발급 실패:", error);
+                // 재발급 실패 시 로그아웃 처리
+                localStorage.removeItem("token");
+                window.location.href = "/login"; // 로그인 페이지로 이동
+                return Promise.reject(error);
+            }
+        }
+
+        return Promise.reject(error);
+    }
+);
+
+export default axiosInstance;

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,0 +1,28 @@
+import React, { createContext, useContext } from "react";
+import { useForm } from "../hooks/useForm";
+const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+    const { formData, handleChange, setFormField } = useForm({
+        email : "",
+        username : "",
+        password : "",
+        jobCategory : "",
+        ageGroup : "",
+        one_liner : ""
+    });
+
+    return (
+        <AuthContext.Provider 
+            value={{ 
+                formData, 
+                handleChange, 
+                setFormField 
+            }}
+        >
+            {children}
+        </AuthContext.Provider>
+    );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/src/pages/FindPW/index.jsx
+++ b/src/pages/FindPW/index.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import axios from 'axios';
 import { 
     Container, 
     Title, 
@@ -8,84 +9,93 @@ import {
     ButtonContainer 
 } from '../../styles/FindPW/style'; // 스타일 파일 경로를 확인하세요.
 import SubmitButton from '../../components/common/SubmitButton'; 
+import { useAuth } from '../../contexts/AuthContext';
 import { useNavigate } from 'react-router-dom'; 
+
+const URL = import.meta.env.VITE_API_URL; 
 
 const FindPW = () => {
     const navigate = useNavigate(); 
-    const [email, setEmail] = useState(''); 
-    const [authCode, setAuthCode] = useState(''); 
-    const [isCodeValid, setIsCodeValid] = useState(false); // 인증번호 유효성 상태
+    const { formData, setFormField } = useAuth();
+    const [authCode, setAuthCode] = useState('');
     const [emailMessage, setEmailMessage] = useState(''); // 이메일 전송 메시지 상태
     const [authCodeMessage, setAuthCodeMessage] = useState(''); // 인증번호 불일치 메시지 상태
     const [timer, setTimer] = useState(0); // 타이머 상태
-    const [isEmailValid, setIsEmailValid] = useState(false); // 이메일 유효성 상태
     const [isResend, setIsResend] = useState(false); // 인증 버튼 상태
-    const [emailVerified, setEmailVerified] = useState(false); // 이메일 인증 여부
 
-    const handleEmailChange = (e) => {
-        setEmail(e.target.value); 
-        setEmailMessage(''); 
-        setIsEmailValid(false); 
-    };
-
-    const handleAuthCodeChange = (e) => {
-        const code = e.target.value;
-        setAuthCode(code); 
-        setAuthCodeMessage(''); 
-        // 인증번호가 입력될 때 유효성 검사
-        if (code) {
-            setIsCodeValid(true);
-        } else {
-            setIsCodeValid(false);
-        }
-    };
-
-    const handleSubmit = (e) => {
-        e.preventDefault();
-        if (timer === 0 && emailVerified) {
-            setAuthCodeMessage('타이머가 만료되었습니다. 재전송 버튼을 눌러주세요.'); // 타이머가 만료된 경우 메시지 표시
-        } else if (isCodeValid && timer > 0) { // 타이머가 0이 아닐 때만 다음으로 이동
-            console.log("이메일:", email, "인증번호:", authCode);
-            navigate("/newPw"); // 비밀번호 입력 페이지로 이동
-        }
-    };
-
-    const validateAuthCode = () => {
-        // 인증번호 검증 로직 (예시)
-        if (authCode === "1234") {
-            setIsCodeValid(true); 
-            setAuthCodeMessage(''); 
-        } else {
-            setIsCodeValid(false); 
-            setAuthCodeMessage('인증번호가 일치하지 않습니다.');
-        }
-    };
+    useEffect(() => {
+        setFormField("email", ""); // 이메일 값을 초기화
+    }, []);
 
     const isValidEmail = (email) => {
         const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
         return emailRegex.test(email);
     };
 
-    const handleVerifyEmail = () => {
-        if (isValidEmail(email)) {
-            // 서버에서 이메일 존재 여부를 확인하는 로직 필요
-            const existingEmails = ["user@example.com"]; // 예시: 존재하는 이메일 리스트
-            if (existingEmails.includes(email)) {
-                setEmailMessage("이메일이 전송되었습니다. 이메일을 확인해주세요.");
-                setIsEmailValid(true); 
-                setTimer(180); 
-                setIsResend(true); // 인증 버튼을 재전송으로 변경
-                setAuthCode(''); // 이메일 재전송 시 인증코드 초기화
-                setAuthCodeMessage(''); // 인증 메시지 초기화
-                setIsCodeValid(false); // 인증 코드 초기화
-                setEmailVerified(true); // 이메일 인증 완료
+    const handleEmailChange = (e) => {
+        setFormField('email', e.target.value);
+        setEmailMessage(''); 
+    };
+
+    const handleAuthCodeChange = (e) => {
+        setAuthCode(e.target.value);
+        setAuthCodeMessage(''); 
+    };
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        if (timer === 0) {
+            setAuthCodeMessage('타이머가 만료되었습니다. 재전송 버튼을 눌러주세요.'); // 타이머가 만료된 경우 메시지 표시
+        } else if (authCode && timer > 0) { // 타이머가 0이 아닐 때만 다음으로 이동
+            console.log("이메일:", formData.email, "인증번호:", authCode);
+            validateAuthCode(authCode); // 인증번호 검증   
+        }
+    };
+
+    const validateAuthCode = async() => {
+        try {
+            // 인증번호 검증 API 호출
+            const response = await axios.get(`${URL}/api/auth/numberCheck`, {
+                params: {
+                    email: formData.email,
+                    number: authCode
+                }
+            });
+            console.log(response.data);
+
+            if(response.data.isSuccess) {
+                setAuthCodeMessage(''); 
+                navigate("/newPw"); // 비밀번호 입력 페이지로 이동
             } else {
-                setEmailMessage("존재하지 않는 계정입니다.");
-                setIsEmailValid(false); 
+                setAuthCodeMessage('인증번호가 일치하지 않습니다.');
             }
-        } else {
-            setEmailMessage("올바르지 않은 이메일 형식입니다.");
-            setIsEmailValid(false); 
+        } catch (error) {
+            console.error('인증번호 확인 에러:', error);
+            setAuthCodeMessage('서버 에러가 발생했습니다. 나중에 다시 시도해주세요.');
+        }
+    };
+
+    
+
+    const handleVerifyEmail = async () => {
+        if (isValidEmail(formData.email)) {
+            try {
+                const responese = await axios.post(`${URL}/api/auth/mailSend`, formData.email, { 
+                    headers: { 'Content-Type': 'text/plain' } 
+                });
+    
+                if (responese.data.isSuccess) {
+                    setEmailMessage("이메일이 전송되었습니다. 이메일을 확인해주세요.");
+                    setTimer(180); 
+                    setIsResend(true); // 인증 버튼을 재전송으로 변경
+                    setFormField('Authorization', ''); // 이메일 재전송 시 인증코드 초기화
+                    setAuthCodeMessage(''); // 인증 메시지 초기화
+                } else {
+                    setEmailMessage("존재하지 않는 계정입니다.");
+                }
+            } catch (error) {
+                setEmailMessage('서버 에러가 발생했습니다. 나중에 다시 시도해주세요.');
+            }
         }
     };
 
@@ -98,8 +108,6 @@ const FindPW = () => {
             }, 1000);
         } else {
             clearInterval(countdown);
-            setIsCodeValid(false); // 타이머가 끝나면 인증번호 유효성 초기화
-            setEmailVerified(false); // 이메일 인증 상태 초기화
         }
         return () => clearInterval(countdown);
     }, [timer]);
@@ -117,7 +125,7 @@ const FindPW = () => {
                 <Input
                     type="email"
                     placeholder="이메일 주소"
-                    value={email}
+                    value={formData.email}
                     onChange={handleEmailChange}
                     required
                 />
@@ -125,9 +133,9 @@ const FindPW = () => {
                     type="button" 
                     onClick={handleVerifyEmail}
                     style={{ 
-                        backgroundColor: isValidEmail(email) ? '#142755' : '#cccccc', 
-                        cursor: isValidEmail(email) ? 'pointer' : 'not-allowed',
-                        opacity: email ? 1 : 0.4 // 이메일 입력 시 투명도 변경
+                        backgroundColor: isValidEmail(formData.email) ? '#142755' : '#cccccc', 
+                        cursor: isValidEmail(formData.email) ? 'pointer' : 'not-allowed',
+                        opacity: formData.email ? 1 : 0.4 // 이메일 입력 시 투명도 변경
                     }}
                 >
                     {isResend ? '재전송' : '인증'}
@@ -135,7 +143,7 @@ const FindPW = () => {
             </InputContainer>
             {emailMessage && (
                 <p style={{ 
-                    color: isEmailValid ? '#142755' : 'red'
+                    color: emailMessage.includes("이메일이 전송") ? '#142755' : 'red'
                 }}>
                     {emailMessage}
                 </p>
@@ -146,7 +154,6 @@ const FindPW = () => {
                     placeholder="인증번호"
                     value={authCode}
                     onChange={handleAuthCodeChange}
-                    onBlur={validateAuthCode} 
                     required
                 />
                 {timer > 0 && (
@@ -170,8 +177,8 @@ const FindPW = () => {
                 <SubmitButton 
                     text="다음" 
                     onClick={handleSubmit} 
-                    disabled={!isCodeValid || timer === 0} // 타이머가 0일 때 비활성화
-                    customOpacity={isCodeValid && timer > 0 ? 1 : 0.4}
+                    disabled={!authCode || timer === 0 || authCodeMessage} // 인증번호가 없거나, 타이머가 0이거나, 인증번호가 틀리면 비활성화
+                    customOpacity={authCode && timer > 0 ? 1 : 0.4}
                 />
             </ButtonContainer>
         </Container>

--- a/src/pages/SetPW/index.jsx
+++ b/src/pages/SetPW/index.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
 import { 
     Container, 
     Title, 
@@ -12,24 +13,23 @@ import { useNavigate } from 'react-router-dom';
 
 const SetPW = () => {
     const navigate = useNavigate();
-    const [password, setPassword] = useState('');
+    const { formData, setFormField } = useAuth();
     const [passwordMessage, setPasswordMessage] = useState('');
     const [isPasswordValid, setIsPasswordValid] = useState(false);
     const [isError, setIsError] = useState(false); 
 
     const handlePasswordChange = (e) => {
-        const newPassword = e.target.value;
-        setPassword(newPassword);
-
+        setFormField('password', e.target.value);
+        
         // 비밀번호 유효성 검사
         const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d)[A-Za-z\d]{8,12}$/; 
         
-        if (newPassword.length > 0) {
+        if (e.target.value.length > 0) {
             setPasswordMessage('비밀번호 제한사항: 영어 대/소문자, 숫자 중 2종류 이상을 조합하여 8자리~12자리로 구성해야 합니다.');
             setIsError(false); // 오류 상태 초기화
         }
 
-        if (passwordRegex.test(newPassword)) {
+        if (passwordRegex.test(e.target.value)) {
             setIsPasswordValid(true);
             setPasswordMessage(''); 
         } else {
@@ -39,10 +39,9 @@ const SetPW = () => {
 
     const handleSubmit = (e) => {
         e.preventDefault();
-
         // 비밀번호 유효성 검사
         const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d)[A-Za-z\d]{8,12}$/;
-        if (!passwordRegex.test(password)) {
+        if (!passwordRegex.test(formData.password)) {
             setIsPasswordValid(false);
             setPasswordMessage('비밀번호는 영어 대/소문자, 숫자를 조합한 8자~12자 이내여야 합니다.');
             setIsError(true); 
@@ -60,7 +59,7 @@ const SetPW = () => {
                 <Input
                     type="password"
                     placeholder="비밀번호"
-                    value={password}
+                    value={formData.password}
                     onChange={handlePasswordChange}
                     required
                 />


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #39 

## 📝작업 내용

> 회원가입 기능을 구현하였습니다.
https://github.com/user-attachments/assets/66061fd9-c8b1-442e-b574-3cd2f9ae84f8

**동영상에서는 이미 계정이 생성된 이메일을 이용한 예시라 마지막에 계정이 생성되지는 않았습니다.


axios instance를 이용해 API호출을 하는 법?
저도 아직 익숙하진 않아서 GPT한테 물어본 사용법을 첨부합니다.

ChatGPT의 말:
ChatGPT
위의 코드는 axiosInstance라는 커스텀 Axios 인스턴스를 생성하고, Access Token 처리와 재발급 로직을 포함하는 요청/응답 인터셉터를 설정한 코드입니다. 이제 이 axiosInstance를 사용하여 API 호출하는 방법을 알려드릴게요.

1. 기본적인 GET 요청
![image](https://github.com/user-attachments/assets/ab553d09-6c91-4961-80d1-b4b4759feed3)


2. POST 요청 (Body 데이터 포함)
![image](https://github.com/user-attachments/assets/cac2afee-c206-4bc1-b933-5122c128fe52)


3. PUT 요청
![image](https://github.com/user-attachments/assets/a14f75db-ea87-410d-b583-ddf96525d4c4)


4. DELETE 요청
![image](https://github.com/user-attachments/assets/1be5119a-ea7b-479c-b49c-dd5fc2994c79)


5. URL에 Query Parameters 추가
![image](https://github.com/user-attachments/assets/326856db-4cb3-4664-8cfd-2123eb4f86a0)



6. 요청에 추가 헤더 설정
![image](https://github.com/user-attachments/assets/d3cd5122-fdb1-4624-a959-6503438e4f06)


주요 사항
Access Token 관리: axiosInstance를 사용하면 자동으로 Authorization 헤더가 설정되므로 추가 설정이 필요 없습니다.
Base URL 설정: 모든 요청은 baseURL로 설정된 import.meta.env.VITE_API_URL을 기준으로 상대 경로를 사용하면 됩니다.
에러 처리: 모든 요청에서 try-catch로 에러를 핸들링해야 에러 발생 시 적절히 대응할 수 있습니다.
위의 예제를 참고하여 axiosInstance를 다양한 API 호출에 활용할 수 있습니다. 필요에 따라 추가 로직을 구현하면 됩니다.
