### PR TITLE
feat: account 컴포넌트 생성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.1.1",
+        "react-swipeable": "^7.0.2",
         "styled-components": "^6.1.13"
       },
       "devDependencies": {
@@ -3755,6 +3756,15 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-swipeable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
+      "integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.1.1",
+    "react-swipeable": "^7.0.2",
     "styled-components": "^6.1.13"
   },
   "devDependencies": {

--- a/src/components/Finance/Account/Activity/Item/index.jsx
+++ b/src/components/Finance/Account/Activity/Item/index.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import SwipeableCard from '../../SwipeableCard';
+import * as S from '../../../../../styles/Finance/Account/Activity/style';
+
+const ActivityItem = ({ activity }) => {
+
+    return (
+        <SwipeableCard>
+            <S.Image src={activity.imageUrl} alt={activity.title} />
+            <S.Content>
+                <S.Subtitle>{activity.title}</S.Subtitle>
+                <S.SubInfo>
+                    <S.Subtitle>{activity.subName}</S.Subtitle>
+                    <S.Price>{activity.amount.toLocaleString()}원</S.Price>
+                </S.SubInfo>
+            </S.Content>
+        </SwipeableCard>
+    );
+};
+
+export default ActivityItem;

--- a/src/components/Finance/Account/Activity/index.jsx
+++ b/src/components/Finance/Account/Activity/index.jsx
@@ -1,0 +1,29 @@
+import React, { useState } from 'react';
+import ActivityItem from './Item';
+import * as S from '../../../../styles/Finance/Account/Activity/style';
+
+const Activity = ({ title, activities }) => {
+    const [showAll, setShowAll] = useState(false);
+    const displayedActivities = showAll ? activities : activities.slice(0, 2);
+    const hasMore = activities.length > 2;
+
+    const handleShowMore = () => {
+        setShowAll(true);
+    };
+
+    return (
+        <S.Section>
+            <S.Title>
+                {title}
+            </S.Title>
+            {displayedActivities.map((activity) => (
+                <ActivityItem key={activity.id} activity={activity} />
+            ))}
+            {!showAll && hasMore && (
+                <S.MoreButton onClick={handleShowMore}>더보기</S.MoreButton>
+            )}
+        </S.Section>
+    );
+};
+
+export default Activity;

--- a/src/components/Finance/Account/DeleteConfirmModal/index.jsx
+++ b/src/components/Finance/Account/DeleteConfirmModal/index.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import styled from 'styled-components';
+
+function DeleteConfirmModal({ title, onCancel, onConfirm }) {
+    return (
+        <ModalBackdrop>
+            <ModalContainer>
+                <ModalTitle>{title}</ModalTitle>
+                <ButtonContainer>
+                    <CancelButton onClick={onCancel}>취소</CancelButton>
+                    <DeleteButton onClick={onConfirm}>삭제</DeleteButton>
+                </ButtonContainer>
+            </ModalContainer>
+        </ModalBackdrop>
+    );
+}
+
+export default DeleteConfirmModal;
+
+/* styled-components */
+const ModalBackdrop = styled.div`
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 999;
+`;
+
+const ModalContainer = styled.div`
+    width: 80%;
+    height: 147px;
+    background: #fff;
+    border-radius: 15px;
+    text-align: center;
+`;
+
+const ModalTitle = styled.p`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 16px;
+    height: 101px;
+`;
+
+const ButtonContainer = styled.div`
+    display: flex;
+    justify-content: space-between;
+    height: 46px;
+`;
+
+const CancelButton = styled.button`
+    width: 50%;
+    background: #B4B4B4;
+    border: none;
+    border-right: 0.5px solid #fff;
+    color: #fff;
+    cursor: pointer;
+    border-radius: 0px 0px 0px 15px;
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 14px;
+`;
+
+const DeleteButton = styled.button`
+    width: 50%;
+    background: #B4B4B4;
+    border: none;
+    border-right: 0.5px solid #fff;
+    color: #fff;
+    cursor: pointer;
+    border-radius: 0px 0px 15px 0px;
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 14px;
+`;

--- a/src/components/Finance/Account/List/Item/index.jsx
+++ b/src/components/Finance/Account/List/Item/index.jsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import SwipeableCard from '../../SwipeableCard';
+import { useSwipeable } from 'react-swipeable';
+import styled from 'styled-components';
+
+//하나의 아이템
+const AccountItem = ({ activity }) => {
+    const { score, title, amount, subName, imageUrl } = activity;
+    // 스와이프가 완전히 끝났을 때 별점을 숨길지 여부
+    const [isStarHidden, setIsStarHidden] = useState(false);
+
+    // 별점 표시 유틸 함수
+    const getStarRating = (score) =>
+        '★'.repeat(score) + '☆'.repeat(5 - score);
+
+      // 스와이프 종료 시 별점 상태를 업데이트하는 콜백
+    const handleSwipeEnd = (finalTranslateX) => {
+        // maxSwipe 값이 -62이므로, -62가 설정되면 별점을 숨기고, 그렇지 않으면 보여줌
+        if (finalTranslateX === -62) {
+        setIsStarHidden(true);
+        } else {
+        setIsStarHidden(false);
+        }
+    };
+
+    return (
+        <SwipeableCard onSwipeEnd={handleSwipeEnd}>
+            <Image src={imageUrl} alt={title} />
+            <Content>
+                <SubInfo>
+                    {/* ★ 변경: 별점은 isStarHidden=false일 때만 렌더링 */}
+                    {!isStarHidden && <div>{getStarRating(score)}</div>}
+                    <span>{subName}</span>
+                </SubInfo>
+                <SubInfo>
+                    <div>{title}</div>
+                    <span>{amount.toLocaleString()}원</span>
+                </SubInfo>
+            </Content>
+        </SwipeableCard>
+    );
+}
+
+export default AccountItem;
+
+/* ---------- styled-components ---------- */
+
+const Image = styled.img`
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    object-fit: cover;
+    margin-right: 10px;
+`;
+
+const Content = styled.div`
+    flex: 1;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 16px;
+    color: #818C99;
+`;
+
+const SubInfo = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 38px;
+        
+    /* 자식이 하나일 때 자동 여백을 부여하여 가운데 정렬 */
+        & > :only-child {
+        margin-top: auto;
+        margin-bottom: auto;
+    }
+`;
+

--- a/src/components/Finance/Account/List/index.jsx
+++ b/src/components/Finance/Account/List/index.jsx
@@ -1,0 +1,16 @@
+import React, { useState } from 'react';
+import AccountItem from './Item';
+
+
+//여러 아이템(activities)을 리스트로 표시
+const AccountList = ({ activities }) => {
+    return (
+        <>
+            {activities.map((activity) => (
+                <AccountItem key={activity.accountId} activity={activity} />
+            ))}
+        </>
+    );
+}
+
+export default AccountList;

--- a/src/components/Finance/Account/SwipeableCard/index.jsx
+++ b/src/components/Finance/Account/SwipeableCard/index.jsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { useSwipe } from '../../../../hooks/useSwipe';
+import DeleteConfirmModal from '../DeleteConfirmModal';
+
+const SwipeableCard = ({ children, onSwipeEnd }) => {
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+    const { translateX, isSwiping, handlers } = useSwipe(onSwipeEnd);
+
+    // 실제 삭제를 처리하는 함수
+    const handleDelete = () => {
+        console.log('삭제');
+        setIsDeleteModalOpen(false);
+    };
+
+    return (
+        <Wrapper>
+            <DeleteArea onClick={() => setIsDeleteModalOpen(true)}>
+                삭제
+            </DeleteArea>
+            <CardContent 
+                $translateX={translateX} 
+                $isSwiping={isSwiping} 
+                {...handlers}
+            >
+                {children}
+            </CardContent>
+            {/* 삭제 확인 모달 */}
+            {isDeleteModalOpen && (
+                <DeleteConfirmModal
+                title="가계부를 삭제하시겠습니까?"
+                onCancel={() => setIsDeleteModalOpen(false)}
+                onConfirm={handleDelete}
+                />
+            )}
+        </Wrapper>
+    );
+};
+
+export default SwipeableCard;
+
+const Wrapper = styled.div`
+    position: relative;
+    background-color: #F7F7F7;
+    border-radius: 5px;
+    height: 90px;
+    overflow: hidden;
+`;
+
+const DeleteArea = styled.div`
+    position: absolute;
+    top: 0;
+    right: 1px;
+    bottom: 1px;
+    width: 62px;
+    border-radius: 0 5px 5px 0;
+    background-color: #F17357;
+    color: #fff;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+`;
+
+const CardContent = styled.div`
+    position: relative;
+    display: flex;
+    align-items: center;
+    background-color: #F7F7F7;
+    width: calc(100% - 32px);
+    height: 50px;
+    padding: 20px 16px;
+    transform: translateX(${props => props.$translateX}px);
+    transition: ${props => (props.$isSwiping ? 'none' : 'transform 0.3s ease')};
+`;

--- a/src/hooks/useAccountData.js
+++ b/src/hooks/useAccountData.js
@@ -1,0 +1,29 @@
+import { useState, useEffect } from "react";
+import axiosInstance from "../api/axiosInstance.js";
+
+export const useAccountData = (data, url, params) => {
+    const [accountData, setAccountData] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        if(!data) return;
+
+        const fetchAccountData = async () => {
+            setLoading(true);
+            setError(null);
+            try {
+                const response = await axiosInstance.get(url, { params });
+                setAccountData(response.data.result);
+            } catch (err) {
+                setError(err);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchAccountData();
+    }, [data]);
+
+    return { accountData, loading, error };
+};

--- a/src/hooks/useSwipe.js
+++ b/src/hooks/useSwipe.js
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import { useSwipeable } from 'react-swipeable';
+
+export const useSwipe = (onSwipeEnd) => {
+    const [translateX, setTranslateX] = useState(0);
+    const [isSwiping, setIsSwiping] = useState(false);
+    const maxSwipe = -62;
+
+    const handlers = useSwipeable({
+        onSwiping: ({ deltaX, dir }) => {
+            setIsSwiping(true);
+            let newX = translateX + (dir === 'Left' ? -Math.abs(deltaX) : Math.abs(deltaX));
+            if (newX < maxSwipe) newX = maxSwipe;
+            if (newX > 0) newX = 0;
+            setTranslateX(newX);
+        },
+        onSwiped: () => {
+            setIsSwiping(false);
+            // 이동 거리가 절반 이상이면 고정, 아니면 원래 위치로 복귀
+            const finalTranslateX = translateX <= maxSwipe / 2 ? maxSwipe : 0;
+            setTranslateX(finalTranslateX);
+            if (onSwipeEnd) {
+                onSwipeEnd(finalTranslateX);
+            }        
+        },
+        trackMouse: true, // PC에서도 마우스 드래그 인식
+    });
+
+    return { translateX, isSwiping, handlers };
+};

--- a/src/pages/Finance/FinanceMain/index.jsx
+++ b/src/pages/Finance/FinanceMain/index.jsx
@@ -1,20 +1,53 @@
 import React from 'react';
+import { useDate } from '../../../contexts/DateContext';
+import { useAccountData } from '../../../hooks/useAccountData';
+
 import NavBar from '../../../components/common/NavBar/index';
 import Satisfaction from '../../../components/Finance/Satisfaction';
 import Calendar from '../../../components/Finance/Calendar/index';
 import FinancePlusButton from '../../../components/common/FloatingButton/FinancePlusButton';
+import AccountList from '../../../components/Finance/Account/List';
 import BottomBar from '../../../components/common/BottomBar';
 
-import { Container } from '../../../styles/Finance/style';
+import { Container, Today } from '../../../styles/Finance/style';
 import Bell from '../../../assets/icons/common/Bell.svg';
 
 const FinanceMain = () => {
+    const { selectedDate } = useDate();
+    const { accountData, loading, error } = useAccountData(selectedDate, `/api/calendar/${selectedDate.year}/${selectedDate.month}/${selectedDate.day}`);
+    
+    const accounts = [
+        {
+            accountId: 1,
+            score: 5,
+            title: '식비',
+            amount: 10000,
+            subName: '맛있는 점심',
+            imageUrl: '',
+        },
+    ];
+
+    // {accountData && accountData.map((account) => (
+    //     <AccountDetail
+    //         key={account.id}
+    //         score={account.score}
+    //         title={account.title}
+    //         amount={account.amount}
+    //         subName={account.subName}
+    //         imageUrl={account.imageUrl}
+    //     />
+    // ))}
+
+    
+
     return (
         <Container>
             <NavBar icon={Bell} modalTop="75px"/>
             <Satisfaction />
             <Calendar header={`지출 0원 수익 0원`} />
             <FinancePlusButton />
+            <Today>{selectedDate.day}일</Today>
+            <AccountList activities={accounts} />
             <BottomBar />
         </Container>
     );

--- a/src/pages/Finance/Report/index.jsx
+++ b/src/pages/Finance/Report/index.jsx
@@ -1,14 +1,77 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useAccountData } from '../../../hooks/useAccountData';
+import { useDate } from '../../../contexts/DateContext';
+
 import BeforeHeader from '../../../components/common/BeforeHeader';
 import NavBar from '../../../components/common/NavBar';
+import Activity from '../../../components/Finance/Account/Activity';
 import { Container } from '../../../styles/Finance/style';
 
 const Report = () => {
+    const { selectedDate } = useDate();
+    const { accountData: activities, loading, error } = useAccountData(
+        selectedDate, 
+        `/api/account/report/${selectedDate.year}/${selectedDate.month}`
+    );
+
+    const activityList = [
+        {
+            id: 1,
+            title: '운동하기',
+            amount: 0,
+            subName: '운동',
+            imageUrl: '',
+        },
+        {
+            id: 2,
+            title: '독서하기',
+            amount: 0,
+            subName: '독서',
+            imageUrl: '',
+        },
+        {   
+            id: 3,
+            title: '영화보기',
+            amount: 0,
+            subName: '영화',
+            imageUrl: '',
+        },
+    ];
+
+
+    // {/* 아쉬운 활동 줄이기 (★1~2점) */}
+    // {activities?.reduceActivity?.length > 0 && (
+    //     <Activity 
+    //         title="아쉬운 활동 줄이기 ★1~2점" 
+    //         activities={activities.reduceActivity} 
+    //     />
+    // )}
+
+    // {/* 만족스러운 활동 늘리기 (★4~5점) */}
+    // {activities?.satisfactoryActivity?.length > 0 && (
+    //     <Activity 
+    //         title="만족스러운 활동 늘리기 ★4~5점" 
+    //         activities={activities.satisfactoryActivity} 
+    //     />
+    // )}
+
+    // {/* 괜찮은 활동 유지하기 (★3점) */}
+    // {activities?.maintainActivity?.length > 0 && (
+    //     <Activity 
+    //         title="괜찮은 활동 유지하기 ★3점" 
+    //         activities={activities.maintainActivity} 
+    //     />
+    // )}
 
     return (
         <Container>
             <BeforeHeader text="경제 활동 만족도 레포트" />
             <NavBar modalTop="142px" />
+            <Activity 
+                title="아쉬운 활동 줄이기 ★1~2점" 
+                activities={activityList} 
+            />
+
         </Container>
     );
 };

--- a/src/styles/Finance/Account/Activity/style.js
+++ b/src/styles/Finance/Account/Activity/style.js
@@ -1,0 +1,80 @@
+import styled from 'styled-components';
+
+export const Section = styled.div`
+    display: flex;
+    flex-direction: column;
+    background: #F7F7F7;
+    width: calc(100% - 32px);
+    height: auto;
+    padding: 16px;
+    border-radius: 5px;
+    gap: 20px;
+    box-shadow: 0px 0px 3px 0px #00000040;
+`;
+
+export const Title = styled.div`
+    font-weight: 600;
+    font-size: 18px;
+    line-height: 18px;
+    color: #142755;
+`;
+
+export const Card = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    width: calc(100% - 32px);
+    height: 50px;
+    padding: 20px 16px; // 상하 20px, 좌우 16px
+    background: #F7F7F7;
+    border: none;
+    transform: translateX(${(props) => props.translateX}px);
+    transition: ${(props) => (props.isSwiping ? 'none' : 'transform 0.3s ease')};
+`;
+
+export const Image = styled.img`
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    margin-right: 16px;
+`;
+
+export const Content = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: calc(100% - 66px);
+`;
+
+export const Subtitle = styled.div`
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 16px;
+    color: #818C99;
+`;
+
+export const SubInfo = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 38px;
+`;
+
+export const Price = styled.div`
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 16px;
+    color: #818C99;
+`;
+
+export const MoreButton = styled.button`
+    font-weight: 500;
+    font-size: 16px;
+    line-height: 16px;
+    cursor: pointer;
+    color: #B4B4B4;
+    background: transparent;
+    border: none;
+`;
+

--- a/src/styles/Finance/style.js
+++ b/src/styles/Finance/style.js
@@ -9,3 +9,10 @@ export const Container = styled.div`
     padding: 44px 20px 24px 20px; // top right bottom left
     gap: 20px;
 `;
+
+export const Today = styled.div`
+    font-weight: 600;
+    font-size: 20px;
+    line-height: 24px;
+    color: #000000;
+`;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #43

## 📝작업 내용

1.카드 스와이프 기능 추가
-SwipeableCard 컴포넌트와 useSwipe 훅을 통해 사용자가 카드를 왼쪽으로 스와이프하면 ‘삭제’ 버튼이 노출되도록 구현했습니다.
-최대 스와이프 거리를 maxSwipe = -62px로 지정하여, 스와이프 범위를 제한합니다.

2.삭제 확인 모달 분리
-삭제 버튼 클릭 시 나타나는 팝업(DeleteConfirmModal)을 별도 컴포넌트로 분리하여 재사용성과 가독성을 높였습니다.
-“취소”와 “삭제” 두 가지 버튼을 제공하며, 실제 삭제 로직이나 UI는 상위 컴포넌트(SwipeableCard)에서 처리합니다.

3. Activity/AccountItem 리팩토링
-기존 Activity 컴포넌트가 목록을 표시하고, 각 항목(ActivityItem)에서 SwipeableCard를 활용해 스와이프 UI를 구현했습니다.
-별점(score)을 표시하는 로직은 isStarHidden 여부에 따라 렌더링이 결정되도록 분기 처리했습니다.

4.데이터 fetch 훅 추가
-useAccountData 훅을 통해 서버로부터 데이터를 가져오고 로딩, 에러 상태를 관리합니다(axios 사용).
-호출 부에서 URL과 파라미터를 전달받아 API를 호출하고, 결과를 반환하도록 설계했습니다.

