### PR TITLE
refacotr: 가계부 알림 navigate 수정 / 팔로우 오류 수정

### DIFF
--- a/src/components/Alarm/AlarmCard/index.jsx
+++ b/src/components/Alarm/AlarmCard/index.jsx
@@ -31,7 +31,7 @@ const AlarmCard = ({ alarm, markRead }) => {
     if (resourceType === "POST") {
       navigate(`/community/postdetail/${resourceId}`); 
     } else if (resourceType === "ACCOUNT") {
-      navigate(`/finance/account/${resourceId}`); 
+      navigate(`/finance`); 
     } else {
       navigate(`/community`);
     }    

--- a/src/components/Community/Search/SearchProfile/index.jsx
+++ b/src/components/Community/Search/SearchProfile/index.jsx
@@ -6,7 +6,7 @@ import { followUser, unfollowUser } from "../../../../api/followAPI";
 
 const SearchProfile = ({ profiles = [] }) => {
    const [followStates, setFollowStates] = useState(
-    profiles.map(profile => profile.isFollowing) 
+    profiles.map(profile => profile.followed) 
   );
 
   const toggleFollow = async (index, userId) => {

--- a/src/styles/Community/FollowFinance/Budget/style.js
+++ b/src/styles/Community/FollowFinance/Budget/style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, {keyframes} from 'styled-components';
 
 export const Container = styled.div`
     // padding: 20px;
@@ -25,12 +25,21 @@ export const BarText = styled.div`
     line-height: 19.09px;
 
 `;
+const fillAnimation = (percentage) => keyframes`
+  0% {
+    width: 0%;
+  }
+  100% {
+    width: ${percentage}%;
+  }
+`;
 
 export const Fill = styled.div`
     width: ${(props) => props.percentage || 0}%;
     height: 100%;
     background-color: #142755;
     border-radius: 4px;
+    animation: ${(props) => fillAnimation(props.percentage)} 1s ease-out forwards;
 `;
 
 export const Content = styled.div`

--- a/src/styles/Community/SearchProfile/style.js
+++ b/src/styles/Community/SearchProfile/style.js
@@ -49,4 +49,10 @@ export const FollowButton = styled.button`
     cursor:pointer;
     margin-left: auto; 
     font-size:16px;
+    flex-shrink: 0;
+
+    @media (max-width: 393px) {
+        font-size: 12px;
+    }
+
 `;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

- 가계부 알림 클릭시 navigate 수정하였습니다. 
- 친구 가계부 클릭시 막대그래프 애니메이션 추가 
-  팔로우 버튼 글자 넘침 수정
- 팔로우 버튼 api 연결 수정

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
